### PR TITLE
dbt-core v1.3 renamed attributes for metrics

### DIFF
--- a/models/metrics/metrics.yml
+++ b/models/metrics/metrics.yml
@@ -7,8 +7,8 @@ metrics:
     model: ref('orders')
     description: "Income from all orders less tax"
 
-    type: sum
-    sql: order_total - tax_paid
+    calculation_method: sum
+    expression: order_total - tax_paid
 
     timestamp: ordered_at
     time_grains: [day, week, month, quarter, year]
@@ -22,8 +22,8 @@ metrics:
     model: ref('orders')
     description: "Number of customers with a sale"
 
-    type: count_distinct
-    sql: customer_id
+    calculation_method: count_distinct
+    expression: customer_id
 
     timestamp: ordered_at
     time_grains: [day, week, month, quarter, year]
@@ -36,8 +36,8 @@ metrics:
     model: ref('orders')
     description: "Total expenses per order"
 
-    type: sum
-    sql: order_cost
+    calculation_method: sum
+    expression: order_cost
 
     timestamp: ordered_at
     time_grains: [day, week, month, quarter, year]
@@ -50,8 +50,8 @@ metrics:
     label: Gross Profit
     description: "Revenue minus expenses"
 
-    type: expression
-    sql: "{{ metric('revenue') }} - {{ metric('expenses') }}"
+    calculation_method: derived
+    expression: "{{ metric('revenue') }} - {{ metric('expenses') }}"
 
     timestamp: ordered_at
     time_grains: [day, week, month, quarter, year]


### PR DESCRIPTION
This PR fixes this warning message:
```
dbt-core v1.3 renamed attributes for metrics:
  'sql'              -> 'expression'
  'type'             -> 'calculation_method'
  'type: expression' -> 'calculation_method: derived'
The old metric parameter names will be fully deprecated in v1.4.
Relevant issue here: https://github.com/dbt-labs/dbt-core/issues/5849
```