### PR TITLE
Use dbt-core instead of dbt-utils for current_timestamp

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -60,4 +60,4 @@ tests:
     node_color: "black"
 
 vars:
-  truncate_timespan_to: "{{ dbt_utils.current_timestamp() }}"
+  truncate_timespan_to: "{{ dbt.current_timestamp() }}"


### PR DESCRIPTION
To be certain of full backwards compatibility, we have the `dbt.current_timestamp_backcompat()` macro.

But after examining the code and comparing it within [this chart](https://github.com/dbt-labs/dbt-utils/pull/597#issuecomment-1231074577), I think the replacement made here will work just fine.

This PR addresses this warning:
<img width="856" alt="image" src="https://user-images.githubusercontent.com/44704949/196832917-e5655d3a-6c2b-4e1b-acbc-3b0816fee0b4.png">